### PR TITLE
Fix #35 and add more information if opir exits with non-zero exit code

### DIFF
--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -519,10 +519,19 @@ macro importcImpl*(defs: static[string], compilerArguments, files: static[openAr
       discard staticExec("mkdir " & fname.parentDir)
       writeFile(fname, defs)
       hint "Running: " & cmd
-      let opirOutput = staticExec(cmd).splitLines
-      for i in 0..<opirOutput.high:
-        echo opirOutput[i]
-      opirOutput[^1]
+      let opirRes = gorgeEx(cmd)
+      if opirRes.exitCode != 0:
+        var err = "Opir exited with non-zero exit code " & $opirRes.exitCode
+        # Seems like opir wasn't found (gorgeEx returns -1 exit code on OSError/IOError)
+        if opirRes.output == "" and opirRes.exitCode == -1:
+          err.add ". Are you sure opir is in PATH?"
+        error err
+        "" # error can return
+      else:
+        let opirOutput = opirRes.output.strip(chars=Whitespace).splitLines
+        for i in 0..<opirOutput.high:
+          echo opirOutput[i]
+        opirOutput[^1]
 
 
   hint "Parsing Opir output"

--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -521,12 +521,14 @@ macro importcImpl*(defs: static[string], compilerArguments, files: static[openAr
       hint "Running: " & cmd
       let opirRes = gorgeEx(cmd)
       if opirRes.exitCode != 0:
-        var err = "Opir exited with non-zero exit code " & $opirRes.exitCode
+        var err = "Opir exited with non-zero exit code $1." % $opirRes.exitCode
+        if opirRes.output != "":
+          err.add "\nOpir output: \n" & opirRes.output
         # Seems like opir wasn't found (gorgeEx returns -1 exit code on OSError/IOError)
         if opirRes.output == "" and opirRes.exitCode == -1:
-          err.add ". Are you sure opir is in PATH?"
+          err.add " Are you sure opir is in PATH?"
         error err
-        "" # error can return
+        "" # error is not noreturn
       else:
         let opirOutput = opirRes.output.strip(chars=Whitespace).splitLines
         for i in 0..<opirOutput.high:

--- a/src/opir.nim
+++ b/src/opir.nim
@@ -396,6 +396,9 @@ discard visitChildren(cursor, proc (c, parent: CXCursor, clientData: CXClientDat
 for elem in output:
   if not (elem.hasKey("kind") and elem.hasKey("file")):
     stderr.writeLine red "Invalid element: ", elem
+
+stderr.flushFile()
+stdout.flushFile()
 echo output
 
 disposeTranslationUnit(unit)


### PR DESCRIPTION
Fixes #35. I also added some messages that are shown if opir exits with non-zero exit code, with special-case for empty output and -1 exit code which (in main Nim implementation) means that there was a OSError or IOError raised, usually indicating that the file wasn't found.