### PR TITLE
Fix support for short enums (cuchar, cschar workaround) in generated wrapper

### DIFF
--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -233,7 +233,7 @@ proc createEnum(origName: string, node: JsonNode, state: var State, comment: str
       fname = state.sanitizeName(field["name"].str, "enumval").ident
     if origName.len == 0:
       consts.add fname.declGuard(superQuote do:
-        const `fname`*: `baseType` = `newLit(value)`)
+        const `fname`* = `baseType`(`newLit(value)`))
     else:
       if not values.hasKey(value):
         values[value] = fname

--- a/tests/tenumconst.h
+++ b/tests/tenumconst.h
@@ -11,3 +11,25 @@ enum {
     ANON_B,
     ANON_C = -1
 };
+
+enum {
+    ANON_D = 0,
+
+    // this is ignored now
+    ANON_E = 'E'
+};
+
+#include <limits.h>
+
+typedef enum {
+    SHORT = SHRT_MAX
+} enum_short;
+
+typedef enum {
+    WORD = INT_MAX
+} enum_word;
+
+// does not not work
+// typedef enum {
+//     LONG = LONG_MAX
+// } enum_long;

--- a/tests/tenumconst.nim
+++ b/tests/tenumconst.nim
@@ -2,6 +2,7 @@ import "../src/futhark"
 
 importc:
   path "."
+  compilerArg "-fshort-enums"
   "tenumconst.h"
 
 
@@ -18,3 +19,11 @@ doAssert MY_VAR_E == MY_VAR_A
 doAssert ANON_A == 0
 doAssert ANON_B == 1
 doAssert ANON_C == -1
+
+doAssert sizeof(ANON_D) == 1
+
+doAssert sizeof(SHORT) == 2
+doAssert SHORT.ord == 0x7fff
+
+doAssert sizeof(WORD) == 4
+doAssert WORD.ord == 0x7fffffff


### PR DESCRIPTION
When short enums are used for the const (anonymous or duplicates), you got an error (because you can't assign an int to a char type).

This is a workaround, and nim is deprecating cuchar in favour of uint8, so maybe change uchars to uint8 instead of cuchar in the future. Not sure what the implications are.

Another thing that futhark should support are actual chars in enums, right now only numbers seem to be supported.