### PR TITLE
cstring fix when using typedef

### DIFF
--- a/src/opir.nim
+++ b/src/opir.nim
@@ -72,7 +72,7 @@ proc toNimType(ct: CXType): JsonNode =
   of CXType_Pointer:
     let info = ct.getPointerInfo
     var kind = info.baseType.kind
-    if info.baseType.kind == CXType_Typedef:
+    if kind == CXType_Typedef:
       kind = info.baseType.getTypeDeclaration.getTypedefDeclUnderlyingType.kind
     if info.depth == 1 and kind in {CXType_Char_S, CXType_SChar}:
       %*{"kind": "base", "value": "cstring"}

--- a/src/opir.nim
+++ b/src/opir.nim
@@ -71,7 +71,10 @@ proc toNimType(ct: CXType): JsonNode =
     CXType_LongAccum, CXType_UShortAccum, CXType_UAccum, CXType_ULongAccum, CXType_Complex: %*{"kind": "invalid", "value": "???"}
   of CXType_Pointer:
     let info = ct.getPointerInfo
-    if info.depth == 1 and info.baseType.kind == CXType_CharS:
+    var kind = info.baseType.kind
+    if info.baseType.kind == CXType_Typedef:
+      kind = info.baseType.getTypeDeclaration.getTypedefDeclUnderlyingType.kind
+    if info.depth == 1 and kind in {CXType_Char_S, CXType_SChar}:
       %*{"kind": "base", "value": "cstring"}
     else:
       let baseType = info.baseType.toNimType

--- a/tests/tcstring.c
+++ b/tests/tcstring.c
@@ -1,0 +1,5 @@
+#include "tcstring.h"
+
+int my_func(const TCHAR* string) {
+    return strlen(string);
+}

--- a/tests/tcstring.h
+++ b/tests/tcstring.h
@@ -1,0 +1,6 @@
+#include <string.h>
+typedef char TCHAR;
+typedef signed char TSCHAR;
+typedef unsigned char TUCHAR;
+
+int my_func(const TCHAR* string);

--- a/tests/tcstring.nim
+++ b/tests/tcstring.nim
@@ -1,0 +1,9 @@
+import "../src/futhark"
+
+{.compile: "tcstring.c".}
+
+importc:
+  path "."
+  "tcstring.h"
+
+doAssert my_func("Hello".cstring) == 5


### PR DESCRIPTION
The cstring detection didn't work for `typedef char NAME;`