### PR TITLE
stdint.h integer types in macros

### DIFF
--- a/tests/tstdint.h
+++ b/tests/tstdint.h
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+// Adapted from usage in the wild:
+// https://github.com/boschsensortec/BME68x-Sensor-API/blob/master/bme68x_defs.h
+
+#define TEST_UINT8                         UINT8_C(0xff)
+#define TEST_UINT16                        UINT16_C(0xffff)
+#define TEST_UINT32                        UINT32_C(0xffffffff)
+#define TEST_UINT64                        UINT64_C(18446744073709551615)
+
+#define TEST_INT8                          INT8_C(-128)
+#define TEST_INT16                         INT16_C(-32768)
+#define TEST_INT32                         INT32_C(-2147483648)
+#define TEST_INT64                         INT64_C(-9223372036854775808)

--- a/tests/tstdint.nim
+++ b/tests/tstdint.nim
@@ -1,0 +1,15 @@
+import "../src/futhark"
+
+importc:
+  path "."
+  "tstdint.h"
+
+doAssert TEST_UINT8  == 0xff'u8.uint8
+doAssert TEST_UINT16 == 0xffff'u16.cuint
+doAssert TEST_UINT32 == 0xffffffff'u32.culong
+doAssert TEST_UINT64 == 18446744073709551615'u64.culonglong
+
+doAssert TEST_INT8  == -128'i8.int8
+doAssert TEST_INT16 == -32768'i16.cint
+doAssert TEST_INT32 == -2147483648'i32.clong
+doAssert TEST_INT64 == -9223372036854775808'i64.clonglong


### PR DESCRIPTION
INt16_C, UINT32_C macros and such from stdint.h

Ran into the issue of missing consts when trying to parse https://github.com/boschsensortec/BME68x-Sensor-API/blob/master/bme68x_defs.h

Test included.