### PR TITLE
Fix value 0L in macros

### DIFF
--- a/src/opir.nim
+++ b/src/opir.nim
@@ -380,6 +380,7 @@ proc genMacroDecl(macroDef: CXCursor): JsonNode =
           of 'x', 'X': parseReturn(HexInt, def.replace("'", ""), kind)
           of 'b', 'B': parseReturn(BinInt, def.replace("'", ""), kind)
           of '1'..'9': parseReturn(OctInt, def[1..^1].replace("'", ""), kind)
+          of 'u', 'U', 'l', 'L', 'z', 'Z': parseReturn(BiggestInt, def, kind)
           else: discard
         of '-': parseReturn(BiggestInt, def.replace("'", ""), kind)
         of '1'..'9': parseReturn(BiggestInt, def.replace("'", ""), kind); parseReturn(BiggestUInt, def.replace("'", ""), kind)

--- a/tests/tstdint.h
+++ b/tests/tstdint.h
@@ -3,6 +3,7 @@
 // Adapted from usage in the wild:
 // https://github.com/boschsensortec/BME68x-Sensor-API/blob/master/bme68x_defs.h
 
+#define TEST_UINT8_ZERO                    UINT8_C(0)
 #define TEST_UINT8                         UINT8_C(0xff)
 #define TEST_UINT16                        UINT16_C(0xffff)
 #define TEST_UINT32                        UINT32_C(0xffffffff)

--- a/tests/tstdint.nim
+++ b/tests/tstdint.nim
@@ -4,6 +4,7 @@ importc:
   path "."
   "tstdint.h"
 
+doAssert TEST_UINT8_ZERO == 0'u8.uint8
 doAssert TEST_UINT8  == 0xff'u8.uint8
 doAssert TEST_UINT16 == 0xffff'u16.cuint
 doAssert TEST_UINT32 == 0xffffffff'u32.culong


### PR DESCRIPTION
I removed one line too much in PR #73, making "0U" etc be ignored.