### PR TITLE
Float parsing in macros

### DIFF
--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -516,6 +516,10 @@ proc createConst(origName: string, node: JsonNode, state: var State, comment: st
           let intNode = newNimNode(nnkIntLit)
           intNode.intVal = node["value"].num
           intNode
+        elif node["value"].kind == JFloat:
+          let floatNode = newNimNode(nnkFloatLit)
+          floatNode.floatVal = node["value"].fnum
+          floatNode
         else: return
       elif node["value"].kind == JInt:
         nnkCast.newTree(node["type"].toNimType(state), newLit(node["value"].num))

--- a/src/opir.nim
+++ b/src/opir.nim
@@ -390,7 +390,7 @@ proc genMacroDecl(macroDef: CXCursor): JsonNode =
 
         # Float parsing
         if def.contains('.'):
-          if def.endsWith('f') or def.endsWith('F') or def.endsWith('l') or def.endsWith('L'):
+          if def[^1] in ['f', 'F', 'l', 'L']:
             parseReturn(Float, def.replace("'", "")[0..^2], kind)
           else:
             parseReturn(Float, def.replace("'", ""), kind)

--- a/tests/tmacrodecl.h
+++ b/tests/tmacrodecl.h
@@ -7,6 +7,7 @@
 #define TEST_PLAIN_FLOAT_3                 (123.f)
 #define TEST_PLAIN_FLOAT_4                 (-.0f)
 #define TEST_PLAIN_FLOAT_5                 (-0.f)
+#define TEST_PLAIN_FLOAT_6                 (0.0f)
 
 #define TEST_PLAIN_DOUBLE_1                (123.0)
 

--- a/tests/tmacrodecl.h
+++ b/tests/tmacrodecl.h
@@ -1,0 +1,14 @@
+#define TEST_PLAIN_INT                     (123)
+#define TEST_PLAIN_LONG                    (-2147483648L)
+#define TEST_PLAIN_LONGLONG                (-9223372036854775808LL)
+
+#define TEST_PLAIN_FLOAT_1                 (123.123f)
+#define TEST_PLAIN_FLOAT_2                 (.123f)
+#define TEST_PLAIN_FLOAT_3                 (123.f)
+#define TEST_PLAIN_FLOAT_4                 (-.0f)
+#define TEST_PLAIN_FLOAT_5                 (-0.f)
+
+#define TEST_PLAIN_DOUBLE_1                (123.0)
+
+#define TEST_PLAIN_LONG_DOUBLE_1           (100.0L)
+

--- a/tests/tmacrodecl.nim
+++ b/tests/tmacrodecl.nim
@@ -1,0 +1,19 @@
+import "../src/futhark"
+
+importc:
+  path "."
+  "tmacrodecl.h"
+
+doAssert TEST_PLAIN_INT == 123
+doAssert TEST_PLAIN_LONG == -2147483648
+doAssert TEST_PLAIN_LONGLONG == -9223372036854775808'i64.clonglong
+
+doAssert TEST_PLAIN_FLOAT_1 == 123.123.cfloat
+doAssert TEST_PLAIN_FLOAT_2 == 0.123.cfloat
+doAssert TEST_PLAIN_FLOAT_3 == 123.cfloat
+doAssert TEST_PLAIN_FLOAT_4 == 0.0.cfloat
+doAssert TEST_PLAIN_FLOAT_5 == 0.0.cfloat
+
+doAssert TEST_PLAIN_DOUBLE_1 == 123.cdouble
+
+doAssert TEST_PLAIN_LONG_DOUBLE_1 == 100.clongdouble

--- a/tests/tmacrodecl.nim
+++ b/tests/tmacrodecl.nim
@@ -11,8 +11,9 @@ doAssert TEST_PLAIN_LONGLONG == -9223372036854775808'i64.clonglong
 doAssert TEST_PLAIN_FLOAT_1 == 123.123.cfloat
 doAssert TEST_PLAIN_FLOAT_2 == 0.123.cfloat
 doAssert TEST_PLAIN_FLOAT_3 == 123.cfloat
-doAssert TEST_PLAIN_FLOAT_4 == 0.0.cfloat
-doAssert TEST_PLAIN_FLOAT_5 == 0.0.cfloat
+doAssert TEST_PLAIN_FLOAT_4 == -0.0.cfloat
+doAssert TEST_PLAIN_FLOAT_5 == -0.0.cfloat
+doAssert TEST_PLAIN_FLOAT_6 == 0.0.cfloat
 
 doAssert TEST_PLAIN_DOUBLE_1 == 123.cdouble
 


### PR DESCRIPTION
The parsing relies on Nim's parseFloat pretty much. If the def contains a period, and then trim off the suffix if any.

Ran inte the issue of missing constants when parsing https://github.com/boschsensortec/Bosch-BSEC2-Library/blob/a8fe04a870a459223b3bc3f48cfe2200b9fcc234/src/inc/bsec_datatypes.h#L91