### PR TITLE
OS X-- build out of the box

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,2 @@
+if defined(macosx):
+  switch("passl", "-L/Library/Developer/CommandLineTools/usr/lib/")

--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -649,6 +649,14 @@ macro importc*(imports: varargs[untyped]): untyped =
     let clangIncludePath = getClangIncludePath()
     if clangIncludePath != "":
       cargs.add newLit("-I" & clangIncludePath)
+    when defined(macosx):
+      var sdkVersion = getenv("MAC_SDK")
+
+      if sdkVersion == "":
+        sdkVersion = "14"
+      cargs.add newLit("-I/Library/Developer/CommandLineTools/SDKs/MacOSX" &
+       sdkVersion  & ".sdk/usr/include")
+
   result.add quote do: importcImpl(`defs`, `outputPath`, `cargs`, `files`, `importDirs`, `renames`, `retypes`, RenameCallback(`renameCallback`), OpirCallbacks(`opirCallbacks`), `forwards`)
 
 proc hash*(n: NimNode): Hash = hash(n.treeRepr)


### PR DESCRIPTION
Added a flag to link the default libclang that installs when you have already installed XCode.

I couldn't figure out how to get this into the nimble file without delving into nimble code, so it's living in a new `config.nims`.