### PR TITLE
Small fix for detecting libclang.so on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ get fixed up over time.
 # Installation
 To install Futhark you first need to have clang installed. Installing clang on
 Linux is as simple as just grabbing it from your package manager (e.g. `sudo
-apt install libclang-dev`). To install clang on Windows you need to install
+apt install clang libclang-dev`). To install clang on Windows you need to install
 [LLVM](https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.7) (you
 probably want to grab the `LLVM-15.0.7-win64.exe` version). To install clang on
 macOS, run `xcode-select --install` in the terminal. Opir should then detect

--- a/src/opir.nims
+++ b/src/opir.nims
@@ -11,5 +11,9 @@ elif defined(macosx):
   if libpath.dirExists():
     switch("passL", "-L" & quoteShell(libpath))
     switch("passL", "-Wl,-rpath " & quoteShell(libpath.quoteShell))
+elif defined(linux):
+  const libpath = staticExec("clang -print-resource-dir").strip() / ".." / ".."
+  if (libpath / "libclang.so").fileExists():
+    switch("passL", "-L" & libpath)
 
 switch("passL", "-lclang")

--- a/src/opir.nims
+++ b/src/opir.nims
@@ -12,8 +12,12 @@ elif defined(macosx):
     switch("passL", "-L" & quoteShell(libpath))
     switch("passL", "-Wl,-rpath " & quoteShell(libpath.quoteShell))
 elif defined(linux):
-  const libpath = staticExec("clang -print-file-name=libclang.so").strip().parentDir()
+  const libpath = staticExec("clang -print-file-name=../../libclang.so").strip().parentDir()
   if fileExists(libpath / "libclang.so"):
     switch("passL", "-L" & libpath)
+  else:
+    const libpath2 = staticExec("clang -print-file-name=libclang.so").strip().parentDir()
+    if fileExists(libpath2 / "libclang.so"):
+      switch("passL", "-L" & libpath2)
 
 switch("passL", "-lclang")

--- a/src/opir.nims
+++ b/src/opir.nims
@@ -12,8 +12,8 @@ elif defined(macosx):
     switch("passL", "-L" & quoteShell(libpath))
     switch("passL", "-Wl,-rpath " & quoteShell(libpath.quoteShell))
 elif defined(linux):
-  const libpath = staticExec("clang -print-resource-dir").strip() / ".." / ".."
-  if (libpath / "libclang.so").fileExists():
+  const libpath = staticExec("clang -print-file-name=libclang.so").strip().parentDir()
+  if fileExists(libpath / "libclang.so"):
     switch("passL", "-L" & libpath)
 
 switch("passL", "-lclang")


### PR DESCRIPTION
Using `clang -print-file-name=../../libclang.so` gives the correct path