### PR TITLE
Fix incomplete structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ redeclare existing things, including built in types and names.
 
 ### Opaque type functionality
 If a type is not fully declared in your C headers but is still required for
-your project Futhark will generate a `type SomeType = distinct object` dummy
+your project Futhark will generate a `type SomeType {.incompleteStruct.} = object` dummy
 type for it. Since most C libraries will pass things by pointer this makes sure
 that a `ptr SomeType` can exist and be passed around without having to know
 anything about `SomeType`. Disabling this feature will remove these definitions

--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -874,7 +874,7 @@ macro importcImpl*(defs, outputPath: static[string], compilerArguments, files, i
         ident = state.typeDefMap.getOrDefault(o, origIdent)
       result.add origIdent.declGuard(quote do:
         type
-          `ident`* = distinct object)
+          `ident`* {.incompleteStruct.} = object)
 
   when not nodeclguards:
     # Generate conditionals to define inner object types if not previously defined


### PR DESCRIPTION
`ptr distinct object` for example is invalid and can crash Nim compiler. It should be invalid codegen.
Using `incompleteStruct` because empty structs have zero size in C. The actual struct implementation is usually in the .c file (private members in a way).