### PR TITLE
Fix for pathing issues on windows

### DIFF
--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -656,7 +656,10 @@ macro importc*(imports: varargs[untyped]): untyped =
   if not sysPathDefined:
     let clangIncludePath = getClangIncludePath()
     if clangIncludePath != "":
-      cargs.add newLit("-I" & clangIncludePath)
+      if defined(windows) and windowsHost:
+        cargs.add newLit("-I" & "\"" & clangIncludePath & "\"")
+      else:
+        cargs.add newLit("-I" & clangIncludePath)
   result.add quote do: importcImpl(`defs`, `outputPath`, `cargs`, `files`, `importDirs`, `renames`, `retypes`, RenameCallback(`renameCallback`), OpirCallbacks(`opirCallbacks`), `forwards`)
 
 proc hash*(n: NimNode): Hash = hash(n.treeRepr)


### PR DESCRIPTION
Due to the whitespace between "Program" and "Files" an error occured that Opir cant find : "Files\LLVM\lib\clang\15.0.7\include" I tried to change only the Windows part.