### PR TITLE
Remove incompleteStruct, it generated bad C code

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ redeclare existing things, including built in types and names.
 
 ### Opaque type functionality
 If a type is not fully declared in your C headers but is still required for
-your project Futhark will generate a `type SomeType {.incompleteStruct.} = object` dummy
+your project Futhark will generate a `type SomeType = object` dummy
 type for it. Since most C libraries will pass things by pointer this makes sure
 that a `ptr SomeType` can exist and be passed around without having to know
 anything about `SomeType`. Disabling this feature will remove these definitions

--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -882,7 +882,7 @@ macro importcImpl*(defs, outputPath: static[string], compilerArguments, files, i
         ident = state.typeDefMap.getOrDefault(o, origIdent)
       result.add origIdent.declGuard(quote do:
         type
-          `ident`* {.incompleteStruct.} = object)
+          `ident`* = object)
 
   when not nodeclguards:
     # Generate conditionals to define inner object types if not previously defined


### PR DESCRIPTION
 Remove incompleteStruct, it generated bad C code when accessing the wrapped struct (storing a ptr of it, for example)

With incompleteStruct, Nim expects the type to exist (similar to importc) but because it doesn't it fails in the C compiler.

With plain object, Nim generates an empty C struct, just as the C header does.