### PR TITLE
Add noIdentNormalize compilation flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,19 +205,19 @@ will be exported as well and documentation will be readable. This is mostly
 useful if you want to export documentation but can't use `nodeclguards` (which
 makes even more readable documentation).
 
+### Preventing identifier normalization
+By default, Futhark generates identifiers that are normalized per 
+[`strutils.nimIdentNormalize`](https://nim-lang.org/docs/strutils.html#nimIdentNormalize%2Cstring).
+You might prefer keeping the case convention from your source library consistent 
+with your wrapper and in cases when the source name is a valid Nim identifier you can can use 
+`-d:noIdentNormalize`. For the cases when a source name is not a valid Nim identifier 
+this flag is ignored.
+
 ## Inline functions
 When using Futhark with dynamic libraries it doesn't make sense to wrap inline
 functions. However if you are compiling your code directly against some C code
 these might be useful to you. In this case you can pass `-d:generateInline` to
 generate function definitions for inline functions.
-
-## Preventing identifier normalization
-By default, Futhark generates identifiers that are normalized per 
-[`strutils.nimIdentNormalize`](https://nim-lang.org/docs/strutils.html#nimIdentNormalize%2Cstring).
-You might prefer keeping the case convention from your source library consistent 
-with your wrappe and in cases when the source name is a valid Nim identifier you can can use 
-`-d:noIdentNormalize`. For the cases when a source name is not a valid Nim identifier 
-this flag is ignored.
 
 ## Pre-ANSI C function declarations
 Also known as K&R style functions. By definition C code like

--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ functions. However if you are compiling your code directly against some C code
 these might be useful to you. In this case you can pass `-d:generateInline` to
 generate function definitions for inline functions.
 
+## Preventing identifier normalization
+By default, Futhark generates identifiers that are normalized per 
+[`strutils.nimIdentNormalize`](https://nim-lang.org/docs/strutils.html#nimIdentNormalize%2Cstring).
+You might prefer keeping the case convention from your source library consistent 
+with your wrappe and in cases when the source name is a valid Nim identifier you can can use 
+`-d:noIdentNormalize`. For the cases when a source name is not a valid Nim identifier 
+this flag is ignored.
+
 ## Pre-ANSI C function declarations
 Also known as K&R style functions. By definition C code like
 ```c

--- a/tests/tnoidentnormalize.h
+++ b/tests/tnoidentnormalize.h
@@ -1,0 +1,2 @@
+const int doNot_normalize = 1;
+const int will__normalize = 2;

--- a/tests/tnoidentnormalize.nim
+++ b/tests/tnoidentnormalize.nim
@@ -1,0 +1,26 @@
+import os, strutils
+
+import ../src/futhark
+
+const outputPath = currentSourcePath.parentDir / "tnoidentnormalize_out.nim"
+
+importc:
+  path "."
+  outputPath outputPath
+  "tnoidentnormalize.h"
+
+
+let fObject = open(outputPath, FileMode.fmRead)
+let outputText = fObject.readAll()
+fObject.close()
+
+# Because of Nim's case/underscore insensitivity, the output of `importc`
+# has to be evaluated directly. 
+
+# The existence of the exported identifiers `doNot_normalize`, `willnormalize`, 
+# and the inexistence of exported `donotnormalize` should be sufficient in determining 
+# whether the test has passed.
+
+doAssert " doNot_normalize*" in outputText
+doAssert " willnormalize*" in outputText
+doAssert (not (" donotnormalize*" in outputText))

--- a/tests/tnoidentnormalize.nims
+++ b/tests/tnoidentnormalize.nims
@@ -1,0 +1,2 @@
+--define:noidentnormalize
+--define:nodeclguards

--- a/tests/tnoidentnormalize.nims
+++ b/tests/tnoidentnormalize.nims
@@ -1,2 +1,1 @@
 --define:noidentnormalize
---define:nodeclguards

--- a/tests/tnoidentnormalizecollision.h
+++ b/tests/tnoidentnormalizecollision.h
@@ -1,0 +1,7 @@
+#define my_var 1
+#define myVar 2
+#define myvar 3
+#define MYVAR 4
+#define MY_VAR 5
+#define MyVar 6
+#define My_Var 7

--- a/tests/tnoidentnormalizecollision.nim
+++ b/tests/tnoidentnormalizecollision.nim
@@ -1,0 +1,36 @@
+import os, strutils
+
+import ../src/futhark
+
+const outputPath = currentSourcePath.parentDir / "tnoidentnormalizecollision_out.nim"
+
+importc:
+  path "."
+  outputPath outputPath
+  "tnoidentnormalizecollision.h"
+
+
+let fObject = open(outputPath, FileMode.fmRead)
+let outputText = fObject.readAll()
+fObject.close()
+
+# Test default behavior per tnormalize.nim
+doAssert(my_var == 1)
+doAssert(myVarconst == 2) # Renamed as 1st definition collides
+doAssert(myvarconstC690172C == 3) # Renamed as both 1st and 2nd definition collides
+doAssert(MYVAR == 4)
+doAssert(MY_VARconst == 5) # Renamed as 4th definition collides
+doAssert(MyVarconst2E4AA817 == 6) # Renamed as 4th and 5th definition collides
+doAssert(My_Varconst038D4D97 == 7) # Renamed as 4th and 5th definiton collides
+
+# Manually test identifier case of output
+doAssert " my_var*" in outputText
+doAssert " myVarconst*" in outputText
+doAssert " myvarconstC690172C*" in outputText
+doAssert " MYVAR*" in outputText
+doAssert " MyVarconst2E4AA817*" in outputText
+doAssert " My_Varconst038D4D97*" in outputText
+
+# `myvar` was renamed in the second name collision, so we can check its 
+# nonexistence in the output file.
+doAssert (not (" myvar*" in outputText))

--- a/tests/tnoidentnormalizecollision.nims
+++ b/tests/tnoidentnormalizecollision.nims
@@ -1,0 +1,1 @@
+--define:noidentnormalize


### PR DESCRIPTION
Using the compilation flag `noidentnormalize`, this allows the user to deny identifier normalization to the final output file. 

Although this makes no difference to compilation, using this option will keep the output identifier as-is when the source name is already a valid Nim identifier. This makes editor code completion much nicer when using the generated bindings if you're expecting to use a consistent case convention. 

Added test and updated README to demonstrate the purpose of the flag.