### PR TITLE
Fix compilation errors concerning cleanup

### DIFF
--- a/src/futhark.nim
+++ b/src/futhark.nim
@@ -235,7 +235,9 @@ proc findAlias(kind: JsonNode): string =
   of "array": (if kind["value"].kind == JNull: "" else: findAlias(kind["value"]))
   of "struct", "union", "enum": (if kind.hasKey("name"): kind["name"].str else: "")
   of "proc": (if kind.hasKey("name"): kind["name"].str else: "")
-  else: error("Unknown kind in findAlias: " & $kind)
+  else: 
+    error("Unknown kind in findAlias: " & $kind)
+    ""
 
 proc addUsings(used: var OrderedSet[string], node: JsonNode) =
   case node["kind"].str:
@@ -345,8 +347,10 @@ proc toNimType(json: JsonNode, state: var State): NimNode =
       state.typeNameMap[json["value"].str]
     of "enum":
       error "Unable to resolve nested enums from here"
+      "invalidNestedEnum".ident
     of "struct", "union":
       error "Unable to resolve nested struct/union from here"
+      "invalidNestedStruct".ident
     of "vector":
       nnkObjectTy.newTree(newEmptyNode(), newEmptyNode(), newEmptyNode())
     of "special":
@@ -822,6 +826,7 @@ macro importcImpl*(defs, outputPath: static[string], compilerArguments, files, i
         if opirRes.output == "" and opirRes.exitCode == -1:
           err.add " Are you sure opir is in PATH?"
         error err
+        ""
       else:
         let opirOutput = opirRes.output.strip(chars=Whitespace).splitLines
         for i in 0..<opirOutput.high:


### PR DESCRIPTION
For some reason, the cleanup is messing with compilation. The changes seemed relatively benign, which only adds to the confusion. It gives the error:
```
futhark/src/futhark.nim(232, 28) Error: expression 'kind["value"].str' is of type 'string' and has to be used (or discarded)
```
Here's a simple example of what I think is causing the issue:
```nim
import macros

const x = 1

proc compileContext(): int = 
    case x
    of 1:
        -1
    else:
        error("Compilation error")

macro context() = 
    discard compileContext()

context()
```
Which is malformed to the Nim compiler and gives the error:
```
Error: expression '-1' is of type 'int' and has to be used (or discarded)
```
I added the assumed superfluous lines back, and all is well.

My *guess* is that the compiler can't infer that all case-of branches error or return the correct type at compile time, so an explicit return is required or all branches need to implicitly return the correct type even if they are stopped by `error` before execution would ever happen.

This works, for example:
```nim
import macros

const x = 1

proc compileContext(): int = 
    case x
    of 1:
        return -1
    else:
        error("Compilation error")

macro context() = 
    discard compileContext()

context()
```
So does this:
```nim
import macros

const x = 1

proc compileContext(): int = 
    case x:
    of 1:
        -1
    else:
        error("Compilation error")
        0

macro context() = 
    discard compileContext()

context()
```
Seems like you can disable `error` [returning](https://github.com/nim-lang/Nim/blob/e98c98b46c6677ed6d1c9041d97ef6c2d414b654/lib/core/macros.nim#L434), which is probably the root cause of the issue.