### PR TITLE
fail noisily about clang errors

### DIFF
--- a/src/futhark/opir.nims
+++ b/src/futhark/opir.nims
@@ -7,12 +7,18 @@ when defined(windows):
     switch("passL", "-L" & quoteShell(libpath))
 elif defined(macosx):
   # Default libclang path on macOS
-  const libpath = staticExec("xcode-select -p").strip() / "usr" / "lib"
+  const cmdres = gorgeEx("xcode-select -p")
+  if cmdres.exitCode != 0:
+    raise newException(LibraryError, $cmdres)
+  const libpath = cmdres.output.strip() / "usr" / "lib"
   if libpath.dirExists():
     switch("passL", "-L" & quoteShell(libpath))
     switch("passL", "-Wl,-rpath " & quoteShell(libpath.quoteShell))
 elif defined(linux):
-  const libpath = staticExec("clang -print-file-name=../../libclang.so").strip().parentDir()
+  const cmdres = gorgeEx("clang -print-file-name=../../libclang.so")
+  if cmdres.exitCode != 0:
+    raise newException(LibraryError, $cmdres)
+  const libpath = cmdres.output.strip().parentDir()
   if fileExists(libpath / "libclang.so"):
     switch("passL", "-L" & libpath)
   else:


### PR DESCRIPTION
A small edge-case improvement, makes it easier to fix clang-dependency or nim installation issues.