### PR TITLE
Try several paths for libclang on macOS

### DIFF
--- a/src/futhark/opir.nims
+++ b/src/futhark/opir.nims
@@ -6,14 +6,29 @@ when defined(windows):
   if libpath.dirExists():
     switch("passL", "-L" & quoteShell(libpath))
 elif defined(macosx):
-  # Default libclang path on macOS
-  const cmdres = gorgeEx("xcode-select -p")
-  if cmdres.exitCode != 0:
-    raise newException(LibraryError, $cmdres)
-  const libpath = cmdres.output.strip() / "usr" / "lib"
-  if libpath.dirExists():
+  # Try command-line tools lib path first
+  const libpath = "/Library/Developer/CommandLineTools/usr/lib"
+  if (libpath / "libclang.dylib").fileExists():
     switch("passL", "-L" & quoteShell(libpath))
     switch("passL", "-Wl,-rpath " & quoteShell(libpath.quoteShell))
+  else:
+    const cmdres = gorgeEx("xcode-select -p")
+    if cmdres.exitCode != 0:
+      raise newException(LibraryError, $cmdres)
+    const xcodeselectpath = cmdres.output.strip()
+    const libpaths = @[
+      xcodeselectpath / "usr/lib",
+      xcodeselectpath / "Toolchains/XcodeDefault.xctoolchain/usr/lib",
+    ]
+    for libpath2 in libpaths:
+      if (libpath2 / "libclang.dylib").fileExists():
+        switch("passL", "-L" & quoteShell(libpath2))
+        switch(
+          "passL",
+          "-Wl,-rpath " &
+            quoteShell(libpath2.quoteShell),
+        )
+        break
 elif defined(linux):
   const cmdres = gorgeEx("clang -print-file-name=../../libclang.so")
   if cmdres.exitCode != 0:


### PR DESCRIPTION
On macOS, there are three locations where the system libclang might be:

1. /Library/Developer/CommandLineTools/usr/lib (if Xcode command line tools are installed)
2. $("xcode-select -p”)/Toolchains/usr/lib  (I believe this is older macOS)
3. $("xcode-select -p”)/Toolchains/XcodeDefault.xctoolchain/usr/lib (I believe this is newer macOS)

This change tries all three locations. Fixes #139