### PR TITLE
Make Opir compile on Windows+VCC

### DIFF
--- a/src/futhark/opir.nims
+++ b/src/futhark/opir.nims
@@ -2,9 +2,12 @@ import std/[os, strutils]
 
 when defined(windows):
   # Default LLVM install library path on Windows
-  const libpath = getEnv("ProgramFiles") / "LLVM" / "bin"
+  const libpath = getEnv("ProgramFiles") / "LLVM" / "lib"
   if libpath.dirExists():
-    switch("passL", "-L" & quoteShell(libpath))
+    when defined(vcc):
+      switch("passL", "/link /LIBPATH:" & quoteShell(libpath))
+    else:
+      switch("passL", "-L" & quoteShell(libpath))
 elif defined(macosx):
   # Try command-line tools lib path first
   const libpath = "/Library/Developer/CommandLineTools/usr/lib"
@@ -62,4 +65,7 @@ elif defined(openbsd):
     # parentDir() happens here instead of separate variable
     switch("passL", "-L" & libpath.parentDir())
 
-switch("passL", "-lclang")
+when defined(vcc):
+  switch("passL", "libclang.lib")
+else:
+  switch("passL", "-lclang")

--- a/src/futhark/opir.nims
+++ b/src/futhark/opir.nims
@@ -1,4 +1,4 @@
-import std/os
+import std/[os, strutils]
 
 when defined(windows):
   const binpath = getEnv("LIBCLANG_PATH", getEnv("ProgramFiles")/"LLVM"/"bin")

--- a/src/futhark/opir.nims
+++ b/src/futhark/opir.nims
@@ -1,8 +1,9 @@
-import std/[os, strutils]
+import std/os
 
 when defined(windows):
-  # Default LLVM install library path on Windows
-  const libpath = getEnv("ProgramFiles") / "LLVM" / "lib"
+  const binpath = getEnv("LIBCLANG_PATH", getEnv("ProgramFiles")/"LLVM"/"bin")
+  const libpath = binpath.parentDir()/"lib"
+
   if libpath.dirExists():
     when defined(vcc):
       switch("passL", "/link /LIBPATH:" & quoteShell(libpath))


### PR DESCRIPTION
I'm using LIBCLANG_PATH to get LLVM's installation path.
LIBCLANG_PATH usually points to a /bin directory which contains `libclang.dll`, however we need `libclang.lib`, which is located at `%LIBCLANG_PATH%\..\lib`.
The last commit properly forms the library search path for `libclang.lib`.